### PR TITLE
Correct typo in method "magnetic_raw(self)" (remove "_" before "data_ready" so it can work as intended)

### DIFF
--- a/adafruit_qmc5883p.py
+++ b/adafruit_qmc5883p.py
@@ -177,7 +177,7 @@ class QMC5883P:
         :return: A 3-tuple of X, Y, Z axis raw values
         """
         # Wait for data ready
-        while not self._data_ready:
+        while not self.data_ready:
             time.sleep(0.001)
 
         # Read all 6 bytes at once


### PR DESCRIPTION
This PR is to fix the issue #2 (simple typo). The originator  (Sahli-WS) did not reply to my ping.